### PR TITLE
Fix Material UI theme palette to restore login screen

### DIFF
--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -21,14 +21,15 @@ export const createAppTheme = (mode: PaletteMode) =>
               default: '#0f1117',
               paper: '#161b26'
             },
-      divider: mode === 'light' ? undefined : 'rgba(255, 255, 255, 0.12)',
-      text:
-        mode === 'light'
-          ? undefined
-          : {
+      ...(mode === 'dark'
+        ? {
+            divider: 'rgba(255, 255, 255, 0.12)',
+            text: {
               primary: '#f5f7fa',
               secondary: '#b0b8c4'
             }
+          }
+        : {})
     },
     typography: {
       fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',


### PR DESCRIPTION
## Summary
- update the theme palette so that light mode keeps the default text colors instead of overriding them with undefined values
- retain the custom dark mode colors for divider and text without breaking Material UI expectations

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d39c3171f4832ab60461a68f7d1988