### PR TITLE
Fix projects table layout and handle missing log metadata

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -40,7 +40,7 @@ export interface LogEntry {
   message: string;
   tags: string[];
   timestamp: string;
-  metadata: LogMetadata;
+  metadata?: LogMetadata;
 }
 
 export interface ProjectLogResponse {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -179,34 +179,36 @@ export const DashboardPage = (): JSX.Element => {
                 <Alert severity="success">Критических инцидентов не зафиксировано.</Alert>
               ) : (
                 <List>
-                  {latestIncidents.map((log) => (
-                    <ListItem key={log._id} divider alignItems="flex-start">
-                      <ListItemText
-                        primary={
-                          <Stack direction="row" spacing={1} alignItems="center">
-                            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                              {log.level}
-                            </Typography>
-                            <Chip label={log.projectUuid} size="small" />
-                            <Typography variant="caption" color="text.secondary">
-                              {formatRelative(log.timestamp)}
-                            </Typography>
-                          </Stack>
-                        }
-                        secondary={
-                          <>
-                            <Typography variant="body2" sx={{ mb: 1 }}>
-                              {log.message}
-                            </Typography>
-                            <Typography variant="caption" color="text.secondary">
-                              IP: {log.metadata.ip ?? '—'} · Сервис: {log.metadata.service ?? '—'} · Пользователь:{' '}
-                              {log.metadata.user ?? '—'}
-                            </Typography>
-                          </>
-                        }
-                      />
-                    </ListItem>
-                  ))}
+                  {latestIncidents.map((log) => {
+                    const metadata = log.metadata ?? {};
+                    return (
+                      <ListItem key={log._id} divider alignItems="flex-start">
+                        <ListItemText
+                          primary={
+                            <Stack direction="row" spacing={1} alignItems="center">
+                              <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                                {log.level}
+                              </Typography>
+                              <Chip label={log.projectUuid} size="small" />
+                              <Typography variant="caption" color="text.secondary">
+                                {formatRelative(log.timestamp)}
+                              </Typography>
+                            </Stack>
+                          }
+                          secondary={
+                            <>
+                              <Typography variant="body2" sx={{ mb: 1 }}>
+                                {log.message}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary">
+                                IP: {metadata.ip ?? '—'} · Сервис: {metadata.service ?? '—'} · Пользователь: {metadata.user ?? '—'}
+                              </Typography>
+                            </>
+                          }
+                        />
+                      </ListItem>
+                    );
+                  })}
                 </List>
               )}
             </CardContent>

--- a/frontend/src/pages/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage.tsx
@@ -114,13 +114,16 @@ export const LogsPage = (): JSX.Element => {
         field: 'metadata',
         headerName: 'Метаданные',
         flex: 1,
-        renderCell: (params) => (
-          <Stack spacing={0.5}>
-            <Typography variant="body2">IP: {params.row.metadata.ip ?? '—'}</Typography>
-            <Typography variant="body2">Сервис: {params.row.metadata.service ?? '—'}</Typography>
-            <Typography variant="body2">Пользователь: {params.row.metadata.user ?? '—'}</Typography>
-          </Stack>
-        )
+        renderCell: (params) => {
+          const metadata = params.row.metadata ?? {};
+          return (
+            <Stack spacing={0.5}>
+              <Typography variant="body2">IP: {metadata.ip ?? '—'}</Typography>
+              <Typography variant="body2">Сервис: {metadata.service ?? '—'}</Typography>
+              <Typography variant="body2">Пользователь: {metadata.user ?? '—'}</Typography>
+            </Stack>
+          );
+        }
       }
     ],
     []
@@ -162,9 +165,9 @@ export const LogsPage = (): JSX.Element => {
           row.level,
           row.message.replace(/\n/g, ' '),
           row.tags.join(','),
-          row.metadata.ip ?? '',
-          row.metadata.service ?? '',
-          row.metadata.user ?? ''
+          row.metadata?.ip ?? '',
+          row.metadata?.service ?? '',
+          row.metadata?.user ?? ''
         ].join(';')
       )
     ].join('\n');

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -80,21 +80,6 @@ export const ProjectsPage = (): JSX.Element => {
         )
       },
       {
-        field: 'tags',
-        headerName: 'Теги',
-        flex: 1,
-        renderCell: (params) => (
-          <Stack direction="row" spacing={1} flexWrap="wrap">
-            {params.row.defaultTags.map((tag) => (
-              <Chip key={tag} label={tag} size="small" sx={{ mb: 0.5 }} />
-            ))}
-            {params.row.customTags.map((tag) => (
-              <Chip key={tag} label={tag} color="primary" size="small" sx={{ mb: 0.5 }} />
-            ))}
-          </Stack>
-        )
-      },
-      {
         field: 'telegram',
         headerName: 'Telegram',
         width: 160,
@@ -126,11 +111,12 @@ export const ProjectsPage = (): JSX.Element => {
       {
         field: 'actions',
         headerName: 'Действия',
-        width: 320,
+        flex: 1,
+        minWidth: 320,
         sortable: false,
         filterable: false,
         renderCell: (params) => (
-          <Stack direction="row" spacing={1} flexWrap="wrap">
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ width: '100%' }}>
             <Button size="small" variant="outlined" onClick={() => navigate(`/projects/${params.row.uuid}/edit`)}>
               Изменить
             </Button>
@@ -190,6 +176,8 @@ export const ProjectsPage = (): JSX.Element => {
                 rows={filteredProjects}
                 columns={columns}
                 getRowId={(row) => row.uuid}
+                getRowHeight={() => 'auto'}
+                getEstimatedRowHeight={() => 160}
                 pageSizeOptions={[5, 10, 25]}
                 initialState={{ pagination: { paginationModel: { pageSize: 10, page: 0 } } }}
                 disableRowSelectionOnClick
@@ -197,6 +185,17 @@ export const ProjectsPage = (): JSX.Element => {
                   noRowsLabel: 'Нет проектов',
                   columnMenuLabel: 'Меню',
                   footerTotalVisibleRows: (visibleCount, totalCount) => `${visibleCount.toLocaleString()} из ${totalCount.toLocaleString()}`
+                }}
+                sx={{
+                  '& .MuiDataGrid-row': {
+                    maxHeight: 'none !important'
+                  },
+                  '& .MuiDataGrid-cell': {
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    whiteSpace: 'normal',
+                    py: 1.5
+                  }
                 }}
               />
             </Box>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -135,17 +135,20 @@ export const SettingsPage = (): JSX.Element => {
             {systemLogsQuery.data && (
               <Box sx={{ maxHeight: 320, overflow: 'auto', bgcolor: 'grey.50', borderRadius: 2, p: 2 }}>
                 <Stack spacing={1.5}>
-                  {systemLogsQuery.data.logs.slice(0, 20).map((log) => (
-                    <Box key={log._id} sx={{ borderBottom: '1px solid', borderColor: 'grey.200', pb: 1 }}>
-                      <Typography variant="caption" color="text.secondary">
-                        {formatDateTime(log.timestamp)} · {log.level}
-                      </Typography>
-                      <Typography variant="body2">{log.message}</Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        IP: {log.metadata.ip ?? '—'} · Сервис: {log.metadata.service ?? '—'}
-                      </Typography>
-                    </Box>
-                  ))}
+                  {systemLogsQuery.data.logs.slice(0, 20).map((log) => {
+                    const metadata = log.metadata ?? {};
+                    return (
+                      <Box key={log._id} sx={{ borderBottom: '1px solid', borderColor: 'grey.200', pb: 1 }}>
+                        <Typography variant="caption" color="text.secondary">
+                          {formatDateTime(log.timestamp)} · {log.level}
+                        </Typography>
+                        <Typography variant="body2">{log.message}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          IP: {metadata.ip ?? '—'} · Сервис: {metadata.service ?? '—'}
+                        </Typography>
+                      </Box>
+                    );
+                  })}
                 </Stack>
               </Box>
             )}


### PR DESCRIPTION
## Summary
- adjust the projects grid by removing the tags column and enabling auto row heights so actions and descriptions stay visible
- guard against missing log metadata across dashboards, logs, and settings pages to avoid runtime crashes when the API omits it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3a616d430832abf41edad22e50b7e