### PR TITLE
Update frontend navigation and filtering features

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import {
   Divider,
   Drawer,
   IconButton,
+  Link as MuiLink,
   List,
   ListItemButton,
   ListItemIcon,
@@ -30,7 +31,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRightOutlined';
 import { Link as RouterLink, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import { useThemeMode } from '../../hooks/useThemeMode';
-import { APP_VERSION } from '../../config';
+import { LOGGER_PAGE_URL, LOGGER_VERSION } from '../../config';
 
 const drawerWidth = 260;
 const collapsedDrawerWidth = 80;
@@ -57,7 +58,6 @@ export const AppLayout = (): JSX.Element => {
   const { mode, toggleMode } = useThemeMode();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
 
   const activePath = useMemo(() => {
     if (location.pathname === '/') {
@@ -67,7 +67,7 @@ export const AppLayout = (): JSX.Element => {
     return item?.path ?? '/';
   }, [location.pathname]);
 
-  const isDrawerExpanded = !isCollapsed || isHovered;
+  const isDrawerExpanded = !isCollapsed;
   const currentDrawerWidth = isDrawerExpanded ? drawerWidth : collapsedDrawerWidth;
 
   const drawer = (
@@ -125,11 +125,28 @@ export const AppLayout = (): JSX.Element => {
       </List>
       <Box sx={{ flexGrow: 1 }} />
       <Divider />
-      {isDrawerExpanded && (
+      {isDrawerExpanded && (LOGGER_VERSION || LOGGER_PAGE_URL) && (
         <Box sx={{ p: 2 }}>
-          <Typography variant="caption" color="text.secondary">
-            Версия {APP_VERSION}
-          </Typography>
+          <Stack spacing={1}>
+            {LOGGER_VERSION && (
+              <Typography variant="caption" color="text.secondary">
+                Версия {LOGGER_VERSION}
+              </Typography>
+            )}
+            {LOGGER_PAGE_URL && (
+              <MuiLink
+                href={LOGGER_PAGE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="caption"
+                underline="hover"
+                color="inherit"
+                sx={{ wordBreak: 'break-all' }}
+              >
+                {LOGGER_PAGE_URL}
+              </MuiLink>
+            )}
+          </Stack>
         </Box>
       )}
     </Box>
@@ -200,16 +217,6 @@ export const AppLayout = (): JSX.Element => {
           variant="permanent"
           sx={{ display: { xs: 'none', sm: 'block' } }}
           PaperProps={{
-            onMouseEnter: () => {
-              if (isCollapsed) {
-                setIsHovered(true);
-              }
-            },
-            onMouseLeave: () => {
-              if (isCollapsed) {
-                setIsHovered(false);
-              }
-            },
             sx: {
               boxSizing: 'border-box',
               width: currentDrawerWidth,

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -2,6 +2,12 @@ export const API_URL = (import.meta.env.VITE_API_URL as string | undefined) && i
   ? (import.meta.env.VITE_API_URL as string)
   : '';
 
-export const APP_VERSION = (typeof __APP_VERSION__ !== 'undefined' ? (__APP_VERSION__ as string) : '0.0.0');
+export const LOGGER_VERSION = (import.meta.env.LOGGER_VERSION as string | undefined) &&
+  import.meta.env.LOGGER_VERSION !== ''
+  ? (import.meta.env.LOGGER_VERSION as string)
+  : undefined;
 
-declare const __APP_VERSION__: string;
+export const LOGGER_PAGE_URL = (import.meta.env.LOGGER_PAGE_URL as string | undefined) &&
+  import.meta.env.LOGGER_PAGE_URL !== ''
+  ? (import.meta.env.LOGGER_PAGE_URL as string)
+  : undefined;

--- a/frontend/src/pages/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Card,
   CardContent,
+  Collapse,
   FormControl,
   InputLabel,
   MenuItem,
@@ -23,6 +24,8 @@ import { LogEntry, LogFilter, Project } from '../api/types';
 import { LoadingState } from '../components/common/LoadingState';
 import { ErrorState } from '../components/common/ErrorState';
 import { formatDateTime } from '../utils/formatters';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 const defaultFilter: LogFilter = { uuid: '' };
 
@@ -31,6 +34,7 @@ export const LogsPage = (): JSX.Element => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filterState, setFilterState] = useState<LogFilter>(defaultFilter);
   const [activeFilter, setActiveFilter] = useState<LogFilter | null>(null);
+  const [filtersExpanded, setFiltersExpanded] = useState(false);
 
   const {
     data: projects,
@@ -53,6 +57,15 @@ export const LogsPage = (): JSX.Element => {
       endDate: searchParams.get('endDate') || undefined
     };
     setFilterState(newFilter);
+    const hasAdvancedFilters = Boolean(
+      newFilter.text ||
+        newFilter.user ||
+        newFilter.ip ||
+        newFilter.service ||
+        newFilter.startDate ||
+        newFilter.endDate
+    );
+    setFiltersExpanded((prev) => (hasAdvancedFilters ? true : prev));
     setActiveFilter(newFilter.uuid ? newFilter : null);
   }, [projects, searchParams]);
 
@@ -197,78 +210,114 @@ export const LogsPage = (): JSX.Element => {
       <Card>
         <CardContent>
           <Stack spacing={3}>
-            <Grid container spacing={2}>
-              <Grid size={{ xs: 12, md: 4 }}>
-                <FormControl fullWidth>
-                  <InputLabel id="project-select">Проект</InputLabel>
-                  <Select
-                    labelId="project-select"
-                    label="Проект"
-                    value={filterState.uuid}
-                    onChange={handleSelectChange('uuid')}
-                  >
-                    {(projects ?? []).map((project: Project) => (
-                      <MenuItem key={project.uuid} value={project.uuid}>
-                        {project.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
+            <Stack spacing={2}>
+              <Grid container spacing={2}>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <FormControl fullWidth>
+                    <InputLabel id="project-select">Проект</InputLabel>
+                    <Select
+                      labelId="project-select"
+                      label="Проект"
+                      value={filterState.uuid}
+                      onChange={handleSelectChange('uuid')}
+                    >
+                      {(projects ?? []).map((project: Project) => (
+                        <MenuItem key={project.uuid} value={project.uuid}>
+                          {project.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <FormControl fullWidth>
+                    <InputLabel id="level-select">Уровень</InputLabel>
+                    <Select
+                      labelId="level-select"
+                      label="Уровень"
+                      value={filterState.level ?? ''}
+                      onChange={handleSelectChange('level')}
+                    >
+                      <MenuItem value="">Все</MenuItem>
+                      <MenuItem value="DEBUG">DEBUG</MenuItem>
+                      <MenuItem value="INFO">INFO</MenuItem>
+                      <MenuItem value="WARNING">WARNING</MenuItem>
+                      <MenuItem value="ERROR">ERROR</MenuItem>
+                      <MenuItem value="CRITICAL">CRITICAL</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Grid>
+                <Grid size={{ xs: 12, md: 5 }}>
+                  <TextField label="Тег" fullWidth value={filterState.tag ?? ''} onChange={handleFilterChange('tag')} />
+                </Grid>
               </Grid>
-              <Grid size={{ xs: 12, md: 2 }}>
-                <FormControl fullWidth>
-                  <InputLabel id="level-select">Уровень</InputLabel>
-                  <Select
-                    labelId="level-select"
-                    label="Уровень"
-                    value={filterState.level ?? ''}
-                    onChange={handleSelectChange('level')}
-                  >
-                    <MenuItem value="">Все</MenuItem>
-                    <MenuItem value="DEBUG">DEBUG</MenuItem>
-                    <MenuItem value="INFO">INFO</MenuItem>
-                    <MenuItem value="WARNING">WARNING</MenuItem>
-                    <MenuItem value="ERROR">ERROR</MenuItem>
-                    <MenuItem value="CRITICAL">CRITICAL</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              <Grid size={{ xs: 12, md: 3 }}>
-                <TextField label="Текст" fullWidth value={filterState.text ?? ''} onChange={handleFilterChange('text')} />
-              </Grid>
-              <Grid size={{ xs: 12, md: 3 }}>
-                <TextField label="Тег" fullWidth value={filterState.tag ?? ''} onChange={handleFilterChange('tag')} />
-              </Grid>
-              <Grid size={{ xs: 12, md: 3 }}>
-                <TextField label="Пользователь" fullWidth value={filterState.user ?? ''} onChange={handleFilterChange('user')} />
-              </Grid>
-              <Grid size={{ xs: 12, md: 3 }}>
-                <TextField label="IP" fullWidth value={filterState.ip ?? ''} onChange={handleFilterChange('ip')} />
-              </Grid>
-              <Grid size={{ xs: 12, md: 3 }}>
-                <TextField label="Сервис" fullWidth value={filterState.service ?? ''} onChange={handleFilterChange('service')} />
-              </Grid>
-              <Grid size={{ xs: 12, md: 3 }}>
-                <TextField
-                  label="Начало"
-                  type="datetime-local"
-                  fullWidth
-                  value={filterState.startDate ?? ''}
-                  onChange={handleFilterChange('startDate')}
-                  InputLabelProps={{ shrink: true }}
-                />
-              </Grid>
-              <Grid size={{ xs: 12, md: 3 }}>
-                <TextField
-                  label="Окончание"
-                  type="datetime-local"
-                  fullWidth
-                  value={filterState.endDate ?? ''}
-                  onChange={handleFilterChange('endDate')}
-                  InputLabelProps={{ shrink: true }}
-                />
-              </Grid>
-            </Grid>
+              <Collapse in={filtersExpanded} unmountOnExit>
+                <Grid container spacing={2} sx={{ mt: 0 }}>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <TextField
+                      label="Текст"
+                      fullWidth
+                      value={filterState.text ?? ''}
+                      onChange={handleFilterChange('text')}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <TextField
+                      label="Пользователь"
+                      fullWidth
+                      value={filterState.user ?? ''}
+                      onChange={handleFilterChange('user')}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <TextField
+                      label="IP"
+                      fullWidth
+                      value={filterState.ip ?? ''}
+                      onChange={handleFilterChange('ip')}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <TextField
+                      label="Сервис"
+                      fullWidth
+                      value={filterState.service ?? ''}
+                      onChange={handleFilterChange('service')}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <TextField
+                      label="Начало"
+                      type="datetime-local"
+                      fullWidth
+                      value={filterState.startDate ?? ''}
+                      onChange={handleFilterChange('startDate')}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <TextField
+                      label="Окончание"
+                      type="datetime-local"
+                      fullWidth
+                      value={filterState.endDate ?? ''}
+                      onChange={handleFilterChange('endDate')}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                  </Grid>
+                </Grid>
+              </Collapse>
+              <Box sx={{ alignSelf: { xs: 'stretch', sm: 'flex-start' } }}>
+                <Button
+                  variant="text"
+                  size="small"
+                  onClick={() => setFiltersExpanded((prev) => !prev)}
+                  endIcon={filtersExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                >
+                  {filtersExpanded ? 'Скрыть дополнительные фильтры' : 'Показать дополнительные фильтры'}
+                </Button>
+              </Box>
+            </Stack>
             <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
               <Button variant="contained" onClick={applyFilter} disabled={!filterState.uuid}>
                 Применить фильтры

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+  readonly LOGGER_VERSION?: string;
+  readonly LOGGER_PAGE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,9 +8,8 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [react()],
     define: {
-      __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0'),
       'import.meta.env.VITE_API_URL': JSON.stringify(apiUrl)
     },
-    envPrefix: ['VITE_', 'API_', 'APP_']
+    envPrefix: ['VITE_', 'API_', 'APP_', 'LOGGER_']
   };
 });


### PR DESCRIPTION
## Summary
- keep the sidebar collapsed width fixed, show version and project link from LOGGER_* env vars
- add a UUID copy action on the projects table and hide edit/delete/ping for the Logger Core project
- rework the logs filters into a collapsible panel that exposes advanced options when expanded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b0626cb8832aacf4a0560f79d042