### PR TITLE
Update FAQ log ingestion examples and metadata

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,4 @@
 # URL бекенда Logger API
 API_URL=http://localhost:3000
+LOGGER_VERSION=0.6
+LOGGER_PAGE_URL=https://github.com/valderan/simple-logger

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Simple Logger</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/localization/translations.ts
+++ b/frontend/src/localization/translations.ts
@@ -341,11 +341,11 @@ export const translations: Record<Locale, TranslationRecord> = {
       apiExamples: {
         title: 'API usage examples',
         description:
-          'Use the REST API to authenticate, manage projects, ingest logs and configure ping services. Below are selected examples from the documentation.',
-        login: 'Authentication (Python)',
-        createProject: 'Create project (TypeScript)',
-        ingestLog: 'Ingest log (Go)',
-        whitelist: 'Manage whitelist (Bash)'
+          'Send logs to the collector using the REST endpoint. Below are ready-to-use snippets for popular languages.',
+        ingestLogPython: 'Send log (Python)',
+        ingestLogTypeScript: 'Send log (TypeScript)',
+        ingestLogGo: 'Send log (Go)',
+        ingestLogBash: 'Send log (Bash)'
       },
       environment: {
         title: 'Environment variables',
@@ -698,11 +698,11 @@ export const translations: Record<Locale, TranslationRecord> = {
       apiExamples: {
         title: 'Примеры работы с API',
         description:
-          'REST API позволяет аутентифицироваться, управлять проектами, отправлять логи и настраивать ping-сервисы. Ниже приведены выбранные примеры из документации.',
-        login: 'Авторизация (Python)',
-        createProject: 'Создание проекта (TypeScript)',
-        ingestLog: 'Отправка лога (Go)',
-        whitelist: 'Управление whitelist (Bash)'
+          'Отправляйте логи в коллектор через REST-эндпоинт. Ниже представлены готовые сниппеты для популярных языков.',
+        ingestLogPython: 'Отправка лога (Python)',
+        ingestLogTypeScript: 'Отправка лога (TypeScript)',
+        ingestLogGo: 'Отправка лога (Go)',
+        ingestLogBash: 'Отправка лога (Bash)'
       },
       environment: {
         title: 'Переменные окружения',


### PR DESCRIPTION
## Summary
- update the frontend page title to "Simple Logger"
- replace the FAQ code samples with log ingestion snippets and remove duplicate language labels
- refresh translations and .env example values for documented environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3d3c6ce8c832a82a30481f5550366