### PR TITLE
Improve incident navigation and log filtering

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -51,9 +51,22 @@ export const fetchProjectLogs = async (uuid: string) => {
   return data;
 };
 
+const LOG_FILTER_PARAM_KEYS: (keyof LogFilter)[] = [
+  'uuid',
+  'level',
+  'text',
+  'tag',
+  'user',
+  'ip',
+  'service',
+  'startDate',
+  'endDate'
+];
+
 export const filterLogs = async (filter: LogFilter) => {
   const searchParams = new URLSearchParams();
-  Object.entries(filter).forEach(([key, value]) => {
+  LOG_FILTER_PARAM_KEYS.forEach((key) => {
+    const value = filter[key];
     if (value) {
       searchParams.append(key, value);
     }
@@ -62,9 +75,21 @@ export const filterLogs = async (filter: LogFilter) => {
   return data;
 };
 
+const DELETE_FILTER_PARAM_KEYS: (keyof Omit<LogFilter, 'uuid'>)[] = [
+  'level',
+  'text',
+  'tag',
+  'user',
+  'ip',
+  'service',
+  'startDate',
+  'endDate'
+];
+
 export const deleteLogs = async (uuid: string, filter: Omit<LogFilter, 'uuid'>) => {
   const searchParams = new URLSearchParams();
-  Object.entries(filter).forEach(([key, value]) => {
+  DELETE_FILTER_PARAM_KEYS.forEach((key) => {
+    const value = filter[key];
     if (value) {
       searchParams.append(key, value);
     }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -105,6 +105,8 @@ export interface LogFilter {
   service?: string;
   startDate?: string;
   endDate?: string;
+  projectUuid?: string;
+  logId?: string;
 }
 
 export interface WhitelistPayload {

--- a/frontend/src/localization/translations.ts
+++ b/frontend/src/localization/translations.ts
@@ -193,7 +193,9 @@ export const translations: Record<Locale, TranslationRecord> = {
     logs: {
       title: 'Logs viewer',
       project: 'Project',
+      projectUuid: 'Project UUID',
       level: 'Level',
+      logId: 'Log ID',
       allLevels: 'All',
       tag: 'Tag',
       text: 'Text',
@@ -205,6 +207,7 @@ export const translations: Record<Locale, TranslationRecord> = {
       showFilters: 'Show additional filters',
       hideFilters: 'Hide additional filters',
       apply: 'Apply filters',
+      clear: 'Clear filter',
       export: 'Export to CSV',
       deleteByFilter: 'Delete by filter',
       deleting: 'Deleting...',
@@ -222,6 +225,7 @@ export const translations: Record<Locale, TranslationRecord> = {
         critical: 'CRITICAL',
         all: 'All'
       },
+      actionsHeader: 'Actions',
       metadata: {
         ip: 'IP: {{value}}',
         service: 'Service: {{value}}',
@@ -230,7 +234,8 @@ export const translations: Record<Locale, TranslationRecord> = {
       metadataHeader: 'Metadata',
       messageHeader: 'Message',
       timestampHeader: 'Timestamp',
-      tagsLabel: 'Tags: {{tags}}'
+      tagsLabel: 'Tags: {{tags}}',
+      copyLog: 'Copy log entry'
     },
     ping: {
       title: 'Ping monitoring',
@@ -377,6 +382,7 @@ export const translations: Record<Locale, TranslationRecord> = {
       hide: 'Скрыть',
       show: 'Показать',
       apply: 'Применить',
+      clear: 'Очистить фильтр',
       export: 'Экспорт',
       notAvailable: '—',
       minutesShort: 'мин',
@@ -547,7 +553,9 @@ export const translations: Record<Locale, TranslationRecord> = {
     logs: {
       title: 'Просмотр логов',
       project: 'Проект',
+      projectUuid: 'UUID проекта',
       level: 'Уровень',
+      logId: 'ID записи',
       allLevels: 'Все',
       tag: 'Тег',
       text: 'Текст',
@@ -559,6 +567,7 @@ export const translations: Record<Locale, TranslationRecord> = {
       showFilters: 'Показать дополнительные фильтры',
       hideFilters: 'Скрыть дополнительные фильтры',
       apply: 'Применить фильтры',
+      clear: 'Очистить фильтр',
       export: 'Экспорт в CSV',
       deleteByFilter: 'Удалить по фильтру',
       deleting: 'Очистка...',
@@ -576,6 +585,7 @@ export const translations: Record<Locale, TranslationRecord> = {
         critical: 'CRITICAL',
         all: 'Все'
       },
+      actionsHeader: 'Действия',
       metadata: {
         ip: 'IP: {{value}}',
         service: 'Сервис: {{value}}',
@@ -584,7 +594,8 @@ export const translations: Record<Locale, TranslationRecord> = {
       metadataHeader: 'Метаданные',
       messageHeader: 'Сообщение',
       timestampHeader: 'Время',
-      tagsLabel: 'Теги: {{tags}}'
+      tagsLabel: 'Теги: {{tags}}',
+      copyLog: 'Скопировать лог'
     },
     ping: {
       title: 'Ping-мониторинг',

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,28 @@
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (error) {
+    console.error('Clipboard API copy failed', error);
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  let successful = false;
+  try {
+    successful = document.execCommand('copy');
+  } catch (error) {
+    console.error('Fallback copy failed', error);
+  }
+  document.body.removeChild(textarea);
+
+  return successful;
+};


### PR DESCRIPTION
## Summary
- show project names in the dashboard incidents list and link incidents to the logs page with preset filters
- extend the logs filter form with project UUID and log ID inputs, a clear button, inline ID display, CSV export updates, and a copy action
- add a shared clipboard helper and limit API filters to supported parameters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3e3409250832ab534601bf82a9495