### PR TITLE
Add per-log deletion and improve login page UI

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -60,7 +60,8 @@ const LOG_FILTER_PARAM_KEYS: (keyof LogFilter)[] = [
   'ip',
   'service',
   'startDate',
-  'endDate'
+  'endDate',
+  'logId'
 ];
 
 export const filterLogs = async (filter: LogFilter) => {
@@ -83,7 +84,8 @@ const DELETE_FILTER_PARAM_KEYS: (keyof Omit<LogFilter, 'uuid'>)[] = [
   'ip',
   'service',
   'startDate',
-  'endDate'
+  'endDate',
+  'logId'
 ];
 
 export const deleteLogs = async (uuid: string, filter: Omit<LogFilter, 'uuid'>) => {

--- a/frontend/src/localization/translations.ts
+++ b/frontend/src/localization/translations.ts
@@ -63,6 +63,8 @@ export const translations: Record<Locale, TranslationRecord> = {
       failed: 'Sign-in failed',
       themeLight: 'Switch to light theme',
       themeDark: 'Switch to dark theme',
+      languageToggle: 'Switch language',
+      logoAlt: 'Simple Logger logo',
       apiUrlLabel: 'API URL',
       apiUrlPlaceholder: 'https://example.com/api',
       apiUrlHelp: 'Specify the API base URL you want to use.'
@@ -235,7 +237,8 @@ export const translations: Record<Locale, TranslationRecord> = {
       messageHeader: 'Message',
       timestampHeader: 'Timestamp',
       tagsLabel: 'Tags: {{tags}}',
-      copyLog: 'Copy log entry'
+      copyLog: 'Copy log entry',
+      deleteLog: 'Delete log entry'
     },
     ping: {
       title: 'Ping monitoring',
@@ -423,6 +426,8 @@ export const translations: Record<Locale, TranslationRecord> = {
       failed: 'Не удалось выполнить вход',
       themeLight: 'Включить светлую тему',
       themeDark: 'Включить тёмную тему',
+      languageToggle: 'Переключить язык',
+      logoAlt: 'Логотип Simple Logger',
       apiUrlLabel: 'API URL',
       apiUrlPlaceholder: 'https://example.com/api',
       apiUrlHelp: 'Укажите базовый адрес API, с которым хотите работать.'
@@ -595,7 +600,8 @@ export const translations: Record<Locale, TranslationRecord> = {
       messageHeader: 'Сообщение',
       timestampHeader: 'Время',
       tagsLabel: 'Теги: {{tags}}',
-      copyLog: 'Скопировать лог'
+      copyLog: 'Скопировать лог',
+      deleteLog: 'Удалить лог'
     },
     ping: {
       title: 'Ping-мониторинг',

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,9 +5,12 @@ import {
   Button,
   Container,
   IconButton,
+  Link as MuiLink,
   Paper,
   Stack,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   Typography
 } from '@mui/material';
@@ -21,12 +24,13 @@ import { parseApiError } from '../utils/apiError';
 import { useThemeMode } from '../hooks/useThemeMode';
 import { getApiBaseUrl, setApiBaseUrl } from '../api/client';
 import { useTranslation } from '../hooks/useTranslation';
+import { LOGGER_PAGE_URL, LOGGER_VERSION } from '../config';
 
 export const LoginPage = (): JSX.Element => {
   const navigate = useNavigate();
   const { login, isAuthenticated } = useAuth();
   const { mode, toggleMode } = useThemeMode();
-  const { t } = useTranslation();
+  const { t, language, setLanguage } = useTranslation();
   const [formState, setFormState] = useState({ username: '', password: '', apiUrl: getApiBaseUrl() });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -72,10 +76,45 @@ export const LoginPage = (): JSX.Element => {
     mutation.mutate(payload);
   };
 
+  const showVersionInfo = Boolean(LOGGER_VERSION && LOGGER_PAGE_URL);
+  const logoSrc = mode === 'light' ? '/logo_light.png' : '/logo_dark.png';
+
   return (
-    <Container maxWidth="sm" sx={{ display: 'flex', alignItems: 'center', minHeight: '100vh' }}>
-      <Stack spacing={2} sx={{ width: '100%' }}>
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+    <Container
+      maxWidth="sm"
+      sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', minHeight: '100vh', py: 6 }}
+    >
+      <Stack spacing={4} sx={{ width: '100%' }}>
+        <Stack direction="row" spacing={1.5} justifyContent="flex-end" alignItems="center">
+          <Tooltip title={t('auth.languageToggle')}>
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={language}
+              onChange={(_, value) => {
+                if (value) {
+                  setLanguage(value);
+                }
+              }}
+              aria-label={t('auth.languageToggle')}
+              sx={{
+                borderRadius: 2,
+                '& .MuiToggleButton-root': {
+                  textTransform: 'none',
+                  fontWeight: 600,
+                  px: 1.5,
+                  border: (theme) => `1px solid ${theme.palette.divider}`,
+                  '&.Mui-selected': {
+                    bgcolor: 'primary.main',
+                    color: 'primary.contrastText'
+                  }
+                }
+              }}
+            >
+              <ToggleButton value="en">EN</ToggleButton>
+              <ToggleButton value="ru">RU</ToggleButton>
+            </ToggleButtonGroup>
+          </Tooltip>
           <Tooltip title={mode === 'light' ? t('auth.themeDark') : t('auth.themeLight')}>
             <IconButton
               onClick={toggleMode}
@@ -85,8 +124,21 @@ export const LoginPage = (): JSX.Element => {
               {mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
             </IconButton>
           </Tooltip>
+        </Stack>
+        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+          <Box
+            component="img"
+            src={logoSrc}
+            alt={t('auth.logoAlt')}
+            sx={{
+              width: { xs: 180, sm: 220 },
+              maxWidth: '100%',
+              height: 'auto',
+              objectFit: 'contain'
+            }}
+          />
         </Box>
-        <Paper elevation={6} sx={{ p: 5, width: '100%', borderRadius: 4 }}>
+        <Paper elevation={6} sx={{ p: { xs: 4, sm: 5 }, width: '100%', borderRadius: 4 }}>
           <Typography variant="h4" component="h1" gutterBottom sx={{ fontWeight: 700 }}>
             {t('auth.title')}
           </Typography>
@@ -115,6 +167,7 @@ export const LoginPage = (): JSX.Element => {
                 value={formState.apiUrl}
                 onChange={handleChange('apiUrl')}
                 autoComplete="url"
+                placeholder={t('auth.apiUrlPlaceholder')}
                 helperText={t('auth.apiUrlHelp')}
               />
               {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
@@ -125,6 +178,18 @@ export const LoginPage = (): JSX.Element => {
           </Box>
         </Paper>
       </Stack>
+      {showVersionInfo && (
+        <Box sx={{ mt: 4, textAlign: 'center' }}>
+          <Stack spacing={0.5} alignItems="center">
+            <MuiLink href={LOGGER_PAGE_URL} target="_blank" rel="noopener noreferrer" underline="hover">
+              {LOGGER_PAGE_URL}
+            </MuiLink>
+            <Typography variant="caption" color="text.secondary">
+              {t('navigation.versionLabel', { version: LOGGER_VERSION })}
+            </Typography>
+          </Stack>
+        </Box>
+      )}
     </Container>
   );
 };

--- a/src/api/utils/logFilters.ts
+++ b/src/api/utils/logFilters.ts
@@ -1,4 +1,4 @@
-import { FilterQuery } from 'mongoose';
+import { FilterQuery, Types } from 'mongoose';
 import { LogDocument } from '../models/Log';
 
 export interface LogFilterParams {
@@ -10,6 +10,7 @@ export interface LogFilterParams {
   service?: string;
   startDate?: string;
   endDate?: string;
+  logId?: string;
 }
 
 /**
@@ -34,6 +35,11 @@ export function buildLogFilter(projectUuid: string, params: LogFilterParams): Fi
   }
   if (params.service) {
     query['metadata.service'] = params.service;
+  }
+  if (params.logId) {
+    query._id = Types.ObjectId.isValid(params.logId)
+      ? new Types.ObjectId(params.logId)
+      : new Types.ObjectId('000000000000000000000000');
   }
   if (params.startDate || params.endDate) {
     query.timestamp = {};


### PR DESCRIPTION
## Summary
- add a per-log delete control to the logs table, wiring logId support through the frontend client and backend filter builder
- refresh the login page with themed logos, a language switcher, and optional version/link footer when environment variables are set
- extend localization entries for the new login controls and delete action

## Testing
- npm run lint (frontend)
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f30cabb0832aa3d2ae98f90ceccd