### PR TITLE
Improve sidebar footer logo alignment and linking

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -135,34 +135,45 @@ export const AppLayout = (): JSX.Element => {
       <Divider />
       {isDrawerExpanded && (
         <Box sx={{ p: 2 }}>
-          <Stack spacing={1.5} alignItems="flex-start">
-            <Box
-              component="img"
-              src={logoSrc}
-              alt={t('common.projectName')}
-              sx={{
-                width: '100%',
-                maxWidth: 160,
-                height: 'auto',
-                objectFit: 'contain'
-              }}
-            />
+          <Stack spacing={1.5} alignItems="center" textAlign="center">
             {LOGGER_PAGE_URL ? (
               <MuiLink
                 href={LOGGER_PAGE_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                variant="caption"
                 underline="hover"
                 color="inherit"
-                sx={{ wordBreak: 'break-all' }}
+                aria-label={t('common.projectName')}
+                sx={{ display: 'inline-flex' }}
               >
-                {t('common.projectName')}
+                <Box
+                  component="img"
+                  src={logoSrc}
+                  alt={t('common.projectName')}
+                  sx={{
+                    width: '100%',
+                    maxWidth: 160,
+                    height: 'auto',
+                    objectFit: 'contain',
+                    display: 'block',
+                    mx: 'auto'
+                  }}
+                />
               </MuiLink>
             ) : (
-              <Typography variant="caption" color="text.secondary">
-                {t('common.projectName')}
-              </Typography>
+              <Box
+                component="img"
+                src={logoSrc}
+                alt={t('common.projectName')}
+                sx={{
+                  width: '100%',
+                  maxWidth: 160,
+                  height: 'auto',
+                  objectFit: 'contain',
+                  display: 'block',
+                  mx: 'auto'
+                }}
+              />
             )}
             {LOGGER_VERSION && (
               <Typography variant="caption" color="text.secondary">


### PR DESCRIPTION
## Summary
- remove the "Simple Logger" label from the sidebar footer and center the remaining content
- make the sidebar logo image link to LOGGER_PAGE_URL when configured

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3fe209e18832a9125ab6844c22d14