### PR TITLE
feat: update dashboard ui and persist user preferences

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   AppBar,
   Box,
@@ -39,6 +39,7 @@ import { useTranslation } from '../../hooks/useTranslation';
 
 const drawerWidth = 260;
 const collapsedDrawerWidth = 80;
+const MENU_COLLAPSED_STORAGE_KEY = 'logger:menuCollapsed';
 
 type NavigationItem = {
   labelKey: string;
@@ -62,8 +63,26 @@ export const AppLayout = (): JSX.Element => {
   const { logout } = useAuth();
   const { mode, toggleMode } = useThemeMode();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.localStorage.getItem(MENU_COLLAPSED_STORAGE_KEY) === 'true';
+  });
   const { t, language, setLanguage } = useTranslation();
+
+  const handleToggleCollapsed = useCallback(() => {
+    setIsCollapsed((prev) => {
+      const next = !prev;
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(MENU_COLLAPSED_STORAGE_KEY, next ? 'true' : 'false');
+      }
+
+      return next;
+    });
+  }, []);
 
   const activePath = useMemo(() => {
     if (location.pathname === '/') {
@@ -226,7 +245,7 @@ export const AppLayout = (): JSX.Element => {
               <span>
                 <IconButton
                   color="inherit"
-                  onClick={() => setIsCollapsed((prev) => !prev)}
+                  onClick={handleToggleCollapsed}
                   sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
                 >
                   {isCollapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}

--- a/frontend/src/localization/translations.ts
+++ b/frontend/src/localization/translations.ts
@@ -85,7 +85,7 @@ export const translations: Record<Locale, TranslationRecord> = {
       toggleThemeLight: 'Switch to light theme',
       toggleThemeDark: 'Switch to dark theme',
       logout: 'Sign out',
-      appBarTitle: 'Logger control panel',
+      appBarTitle: 'Control panel',
       versionLabel: 'Version {{version}}'
     },
     dashboard: {
@@ -97,6 +97,9 @@ export const translations: Record<Locale, TranslationRecord> = {
       telegramEnabled: 'Telegram alerts',
       telegramEnabledDescription: 'Projects with active notifications',
       logDistribution: 'Log distribution by level',
+      apiUrlLabel: 'API base URL',
+      apiUrlDescription: 'The client is interacting with this API endpoint.',
+      apiUrlNotConfigured: 'Not configured',
       incidents: 'Latest incidents',
       noIncidents: 'No critical incidents detected.',
       incidentMeta: 'IP: {{ip}} · Service: {{service}} · User: {{user}}',
@@ -452,7 +455,7 @@ export const translations: Record<Locale, TranslationRecord> = {
       toggleThemeLight: 'Включить светлую тему',
       toggleThemeDark: 'Включить тёмную тему',
       logout: 'Выйти',
-      appBarTitle: 'Панель управления Logger',
+      appBarTitle: 'Панель управления',
       versionLabel: 'Версия {{version}}'
     },
     dashboard: {
@@ -464,6 +467,9 @@ export const translations: Record<Locale, TranslationRecord> = {
       telegramEnabled: 'Telegram-уведомления',
       telegramEnabledDescription: 'Проектов с активными оповещениями',
       logDistribution: 'Распределение логов по уровням',
+      apiUrlLabel: 'Базовый адрес API',
+      apiUrlDescription: 'Клиент работает с этим API.',
+      apiUrlNotConfigured: 'Не задан',
       incidents: 'Последние инциденты',
       noIncidents: 'Критических инцидентов не зафиксировано.',
       incidentMeta: 'IP: {{ip}} · Сервис: {{service}} · Пользователь: {{user}}',

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -29,6 +29,7 @@ import { ErrorState } from '../components/common/ErrorState';
 import { formatDateTime, formatRelative } from '../utils/formatters';
 import { LogEntry, Project } from '../api/types';
 import { useTranslation } from '../hooks/useTranslation';
+import { API_URL } from '../config';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -117,13 +118,15 @@ export const DashboardPage = (): JSX.Element => {
   const totalPingServices = pingQueries.reduce((acc, query) => acc + (query.data?.length ?? 0), 0);
   const projectsWithAlerts = projects?.filter((project) => project.telegramNotify.enabled).length ?? 0;
 
+  const apiBaseUrl = API_URL?.trim() ? API_URL : '';
+
   return (
     <Stack spacing={3}>
       <Typography variant="h4" sx={{ fontWeight: 700 }}>
         {t('dashboard.title')}
       </Typography>
       <Grid container spacing={3}>
-        <Grid size={{ xs: 12, md: 4 }}>
+        <Grid size={{ xs: 12, md: 3 }}>
           <Card>
             <CardContent>
               <Typography variant="subtitle2" color="text.secondary">
@@ -138,7 +141,7 @@ export const DashboardPage = (): JSX.Element => {
             </CardContent>
           </Card>
         </Grid>
-        <Grid size={{ xs: 12, md: 4 }}>
+        <Grid size={{ xs: 12, md: 3 }}>
           <Card>
             <CardContent>
               <Typography variant="subtitle2" color="text.secondary">
@@ -153,7 +156,7 @@ export const DashboardPage = (): JSX.Element => {
             </CardContent>
           </Card>
         </Grid>
-        <Grid size={{ xs: 12, md: 4 }}>
+        <Grid size={{ xs: 12, md: 3 }}>
           <Card>
             <CardContent>
               <Typography variant="subtitle2" color="text.secondary">
@@ -164,6 +167,24 @@ export const DashboardPage = (): JSX.Element => {
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 {t('dashboard.telegramEnabledDescription')}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, md: 3 }}>
+          <Card>
+            <CardContent>
+              <Typography variant="subtitle2" color="text.secondary">
+                {t('dashboard.apiUrlLabel')}
+              </Typography>
+              <Typography
+                variant="body1"
+                sx={{ fontWeight: 600, fontFamily: 'monospace', wordBreak: 'break-all' }}
+              >
+                {apiBaseUrl || t('dashboard.apiUrlNotConfigured')}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t('dashboard.apiUrlDescription')}
               </Typography>
             </CardContent>
           </Card>

--- a/frontend/src/pages/FAQPage.tsx
+++ b/frontend/src/pages/FAQPage.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Card, CardContent, Stack, Typography } from '@mui/material';
+import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
 import { useTranslation } from '../hooks/useTranslation';
 
 const pythonIngestLogExample = String.raw`"""Send a structured log message to the collector."""
@@ -155,8 +155,6 @@ const addProjectKeys = [
   'debugMode'
 ] as const;
 
-const environmentKeys = ['apiUrl', 'loggerPageUrl', 'loggerVersion', 'botApiKey', 'jwtSecret', 'mongoUri'] as const;
-
 const apiExamples = [
   { titleKey: 'faq.apiExamples.ingestLogPython', code: pythonIngestLogExample },
   { titleKey: 'faq.apiExamples.ingestLogTypeScript', code: typescriptIngestLogExample },
@@ -242,24 +240,6 @@ export const FAQPage = (): JSX.Element => {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardContent>
-          <Stack spacing={2}>
-            <Typography variant="h6" sx={{ fontWeight: 600 }}>
-              {t('faq.environment.title')}
-            </Typography>
-            <Typography color="text.secondary">{t('faq.environment.description')}</Typography>
-            <Stack spacing={1}>
-              {environmentKeys.map((key) => (
-                <Typography key={key} variant="body1">
-                  {t(`faq.environment.${key}`)}
-                </Typography>
-              ))}
-            </Stack>
-            <Alert severity="info">{t('faq.helpSection.faq')}</Alert>
-          </Stack>
-        </CardContent>
-      </Card>
     </Stack>
   );
 };

--- a/frontend/src/pages/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage.tsx
@@ -42,6 +42,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { copyToClipboard } from '../utils/clipboard';
 
 const defaultFilter: LogFilter = { uuid: '', projectUuid: undefined, logId: undefined };
+const DETAILS_MODE_STORAGE_KEY = 'logger:logsDetailsMode';
 
 export const LogsPage = (): JSX.Element => {
   const queryClient = useQueryClient();
@@ -49,7 +50,13 @@ export const LogsPage = (): JSX.Element => {
   const [filterState, setFilterState] = useState<LogFilter>(defaultFilter);
   const [activeFilter, setActiveFilter] = useState<LogFilter | null>(null);
   const [filtersExpanded, setFiltersExpanded] = useState(false);
-  const [detailsModeEnabled, setDetailsModeEnabled] = useState(false);
+  const [detailsModeEnabled, setDetailsModeEnabled] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.localStorage.getItem(DETAILS_MODE_STORAGE_KEY) === 'true';
+  });
   const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
   const { t } = useTranslation();
   const theme = useTheme();
@@ -288,7 +295,12 @@ export const LogsPage = (): JSX.Element => {
   );
 
   const handleDetailsModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setDetailsModeEnabled(event.target.checked);
+    const isEnabled = event.target.checked;
+    setDetailsModeEnabled(isEnabled);
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DETAILS_MODE_STORAGE_KEY, isEnabled ? 'true' : 'false');
+    }
   };
 
   const handleCellClick = useCallback<GridEventListener<'cellClick'>>(


### PR DESCRIPTION
## Summary
- rename the dashboard header copy and extend translations for the API summary card
- show the configured API base URL on the overview screen and remove the FAQ environment section
- remember the log details toggle and sidebar collapsed state for each user via local storage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43c74e2f4832aa9e4339f1df38753