### PR TITLE
Improve mobile controls and responsive layout

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AppBar,
   Box,
@@ -17,6 +17,7 @@ import {
   ToggleButton,
   ToggleButtonGroup
 } from '@mui/material';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import DashboardIcon from '@mui/icons-material/SpaceDashboardOutlined';
 import FolderIcon from '@mui/icons-material/FolderOutlined';
 import AssignmentIcon from '@mui/icons-material/AssignmentOutlined';
@@ -31,6 +32,8 @@ import LightModeIcon from '@mui/icons-material/LightModeOutlined';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeftOutlined';
 import ChevronRightIcon from '@mui/icons-material/ChevronRightOutlined';
 import HelpIcon from '@mui/icons-material/HelpOutline';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDownOutlined';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUpOutlined';
 import { Link as RouterLink, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import { useThemeMode } from '../../hooks/useThemeMode';
@@ -65,6 +68,7 @@ export const AppLayout = (): JSX.Element => {
   const { logout } = useAuth();
   const { mode, toggleMode } = useThemeMode();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [mobileControlsOpen, setMobileControlsOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') {
       return false;
@@ -77,6 +81,15 @@ export const AppLayout = (): JSX.Element => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const mobileDrawerAnchor = isSmallScreen ? 'top' : 'left';
   const handleMobileClose = () => setMobileOpen(false);
+  const handleToggleMobileControls = useCallback(() => {
+    setMobileControlsOpen((prev) => !prev);
+  }, []);
+  const handleMobileControlsClose = useCallback(() => {
+    setMobileControlsOpen(false);
+  }, []);
+  const handleMobileControlsOpen = useCallback(() => {
+    setMobileControlsOpen(true);
+  }, []);
 
   const handleToggleCollapsed = useCallback(() => {
     setIsCollapsed((prev) => {
@@ -342,19 +355,30 @@ export const AppLayout = (): JSX.Element => {
     </Box>
   );
 
+  useEffect(() => {
+    if (!isSmallScreen && mobileControlsOpen) {
+      setMobileControlsOpen(false);
+    }
+  }, [isSmallScreen, mobileControlsOpen]);
+
   return (
     <Box sx={{ display: 'flex' }}>
       <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
-        <Toolbar sx={{ position: 'relative' }}>
+        <Toolbar
+          sx={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: { xs: 'space-between', sm: 'flex-start' },
+            gap: { xs: 1, sm: 0 }
+          }}
+        >
           <IconButton
             color="inherit"
             aria-label={t('navigation.openMenu')}
             onClick={() => setMobileOpen(true)}
             sx={{
-              display: { xs: 'flex', sm: 'none' },
-              position: { xs: 'absolute', sm: 'static' },
-              left: { xs: '50%', sm: 'auto' },
-              transform: { xs: 'translateX(-50%)', sm: 'none' }
+              display: { xs: 'flex', sm: 'none' }
             }}
           >
             <MenuIcon />
@@ -366,9 +390,57 @@ export const AppLayout = (): JSX.Element => {
           >
             {t('navigation.appBarTitle')}
           </Typography>
+          <Box sx={{ display: { xs: 'flex', sm: 'none' }, alignItems: 'center', ml: 'auto' }}>
+            <IconButton
+              color="inherit"
+              aria-label={mobileControlsOpen ? t('navigation.hideControls') : t('navigation.showControls')}
+              onClick={handleToggleMobileControls}
+            >
+              {mobileControlsOpen ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+            </IconButton>
+          </Box>
           {desktopControls}
         </Toolbar>
       </AppBar>
+      {isSmallScreen && (
+        <SwipeableDrawer
+          anchor="top"
+          open={mobileControlsOpen}
+          onOpen={handleMobileControlsOpen}
+          onClose={handleMobileControlsClose}
+          swipeAreaWidth={48}
+          disableDiscovery
+          SwipeAreaProps={{
+            style: {
+              top: 56
+            }
+          }}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            '& .MuiDrawer-paper': {
+              mt: '56px',
+              height: 'auto',
+              maxHeight: 'calc(100vh - 56px)',
+              borderBottomLeftRadius: 20,
+              borderBottomRightRadius: 20,
+              backgroundImage: 'none'
+            }
+          }}
+        >
+          <Box sx={{ p: 2, pt: 1 }}>
+            <Stack spacing={2} alignItems="center">
+              <IconButton
+                color="inherit"
+                onClick={handleToggleMobileControls}
+                aria-label={t('navigation.closeControls')}
+              >
+                <KeyboardArrowUpIcon />
+              </IconButton>
+              {mobileControls}
+            </Stack>
+          </Box>
+        </SwipeableDrawer>
+      )}
       <Box
         component="nav"
         sx={{

--- a/frontend/src/localization/translations.ts
+++ b/frontend/src/localization/translations.ts
@@ -87,7 +87,10 @@ export const translations: Record<Locale, TranslationRecord> = {
       logout: 'Sign out',
       appBarTitle: 'Control panel',
       versionLabel: 'Version {{version}}',
-      openMenu: 'Open navigation menu'
+      openMenu: 'Open navigation menu',
+      showControls: 'Open control panel',
+      hideControls: 'Hide control panel',
+      closeControls: 'Hide control panel'
     },
     dashboard: {
       title: 'Overview',
@@ -458,7 +461,10 @@ export const translations: Record<Locale, TranslationRecord> = {
       logout: 'Выйти',
       appBarTitle: 'Панель управления',
       versionLabel: 'Версия {{version}}',
-      openMenu: 'Открыть меню навигации'
+      openMenu: 'Открыть меню навигации',
+      showControls: 'Открыть панель управления',
+      hideControls: 'Скрыть панель управления',
+      closeControls: 'Скрыть панель управления'
     },
     dashboard: {
       title: 'Общая сводка',

--- a/frontend/src/pages/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage.tsx
@@ -150,7 +150,7 @@ export const LogsPage = (): JSX.Element => {
       {
         field: 'timestamp',
         headerName: t('logs.timestampHeader'),
-        minWidth: 200,
+        minWidth: isSmDown ? 160 : 200,
         flex: isMdDown ? 1.1 : 0.8,
         renderCell: (params) => (
           <Stack spacing={0.5} sx={{ width: '100%' }}>
@@ -234,7 +234,7 @@ export const LogsPage = (): JSX.Element => {
       {
         field: 'actions',
         headerName: t('logs.actionsHeader'),
-        minWidth: isSmDown ? 200 : 220,
+        minWidth: isSmDown ? 180 : 220,
         flex: isSmDown ? 1.05 : 0.9,
         sortable: false,
         filterable: false,
@@ -612,7 +612,13 @@ export const LogsPage = (): JSX.Element => {
                     project: logsQuery.data.project.name
                   })}
                 </Alert>
-                <Box sx={{ height: isSmDown ? 'auto' : 520, width: '100%' }}>
+                <Box
+                  sx={{
+                    width: '100%',
+                    height: isSmDown ? 'auto' : 520,
+                    overflowX: 'auto'
+                  }}
+                >
                   <DataGrid
                     rows={displayLogs}
                     columns={columns}
@@ -626,6 +632,7 @@ export const LogsPage = (): JSX.Element => {
                     onCellClick={handleCellClick}
                     localeText={{ noRowsLabel: t('logs.noLogs') }}
                     sx={{
+                      minWidth: isSmDown ? 560 : undefined,
                       '& .MuiDataGrid-cell': {
                         alignItems: 'flex-start',
                         py: 1.5,
@@ -645,6 +652,11 @@ export const LogsPage = (): JSX.Element => {
                       },
                       '& .MuiDataGrid-cell[data-field="actions"]': {
                         cursor: 'default'
+                      },
+                      '& .MuiDataGrid-footerContainer': {
+                        flexWrap: 'wrap',
+                        gap: 1,
+                        justifyContent: { xs: 'center', sm: 'space-between' }
                       }
                     }}
                     density={isSmDown ? 'comfortable' : 'standard'}

--- a/frontend/src/pages/PingServicesPage.tsx
+++ b/frontend/src/pages/PingServicesPage.tsx
@@ -112,13 +112,13 @@ export const PingServicesPage = (): JSX.Element => {
       {
         field: 'interval',
         headerName: t('ping.intervalHeader'),
-        minWidth: 140,
+        minWidth: isSmDown ? 120 : 140,
         flex: isMdDown ? 0.7 : 0.5
       },
       {
         field: 'lastStatus',
         headerName: t('ping.statusHeader'),
-        minWidth: 160,
+        minWidth: isSmDown ? 140 : 160,
         flex: isMdDown ? 0.9 : 0.6,
         renderCell: (params) => {
           const status = params.row.lastStatus ?? 'unknown';
@@ -131,13 +131,17 @@ export const PingServicesPage = (): JSX.Element => {
                 : status === 'down'
                   ? t('ping.status.down')
                   : t('ping.status.unknown');
-          return <Alert severity={color}>{label}</Alert>;
+          return (
+            <Alert severity={color} sx={{ width: '100%', px: 1.5, py: 1 }}>
+              {label}
+            </Alert>
+          );
         }
       },
       {
         field: 'lastCheckedAt',
         headerName: t('ping.lastCheckHeader'),
-        minWidth: 200,
+        minWidth: isSmDown ? 180 : 200,
         flex: isMdDown ? 1 : 0.7,
         renderCell: (params) => (
           <Stack>
@@ -167,7 +171,7 @@ export const PingServicesPage = (): JSX.Element => {
         )
       }
     ],
-    [isMdDown, t]
+    [isMdDown, isSmDown, t]
   );
 
   const columnVisibilityModel = useMemo(
@@ -229,7 +233,13 @@ export const PingServicesPage = (): JSX.Element => {
                 {t('ping.addService')}
               </Button>
             </Stack>
-            <Box sx={{ height: isSmDown ? 'auto' : 500, width: '100%' }}>
+            <Box
+              sx={{
+                width: '100%',
+                height: isSmDown ? 'auto' : 500,
+                overflowX: 'auto'
+              }}
+            >
               <DataGrid
                 rows={services ?? []}
                 columns={columns}
@@ -241,6 +251,7 @@ export const PingServicesPage = (): JSX.Element => {
                 disableRowSelectionOnClick
                 localeText={{ noRowsLabel: t('ping.noServices') }}
                 sx={{
+                  minWidth: isSmDown ? 560 : undefined,
                   '& .MuiDataGrid-cell': {
                     alignItems: 'flex-start',
                     whiteSpace: 'normal',
@@ -251,6 +262,11 @@ export const PingServicesPage = (): JSX.Element => {
                     whiteSpace: 'normal',
                     lineHeight: 1.2,
                     fontSize: { xs: '0.8rem', sm: '0.875rem' }
+                  },
+                  '& .MuiDataGrid-footerContainer': {
+                    flexWrap: 'wrap',
+                    gap: 1,
+                    justifyContent: { xs: 'center', sm: 'space-between' }
                   }
                 }}
                 density={isSmDown ? 'comfortable' : 'standard'}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -118,7 +118,7 @@ export const ProjectsPage = (): JSX.Element => {
       {
         field: 'telegram',
         headerName: t('projects.columns.telegram'),
-        minWidth: 160,
+        minWidth: isSmDown ? 140 : 160,
         flex: isMdDown ? 1 : 0.7,
         renderCell: (params) =>
           params.row.telegramNotify.enabled ? (
@@ -135,7 +135,7 @@ export const ProjectsPage = (): JSX.Element => {
       {
         field: 'accessLevel',
         headerName: t('projects.columns.access'),
-        minWidth: 140,
+        minWidth: isSmDown ? 120 : 140,
         flex: isMdDown ? 0.8 : 0.5,
         valueGetter: (value) => value,
         renderCell: (params) => <Chip label={params.row.accessLevel} size="small" color="info" />
@@ -143,7 +143,7 @@ export const ProjectsPage = (): JSX.Element => {
       {
         field: 'createdAt',
         headerName: t('projects.columns.createdAt'),
-        minWidth: 180,
+        minWidth: isSmDown ? 160 : 180,
         flex: isMdDown ? 0.9 : 0.6,
         renderCell: (params) => <Typography variant="body2">{formatDateTime(params.row.createdAt)}</Typography>
       },
@@ -151,7 +151,7 @@ export const ProjectsPage = (): JSX.Element => {
         field: 'actions',
         headerName: t('projects.columns.actions'),
         flex: 1.2,
-        minWidth: isSmDown ? 240 : 360,
+        minWidth: isSmDown ? 200 : 360,
         sortable: false,
         filterable: false,
         renderCell: (params) => (
@@ -260,7 +260,13 @@ export const ProjectsPage = (): JSX.Element => {
                 {t('projects.addProject')}
               </Button>
             </Stack>
-            <Box sx={{ height: isSmDown ? 'auto' : 520, width: '100%' }}>
+            <Box
+              sx={{
+                width: '100%',
+                height: isSmDown ? 'auto' : 520,
+                overflowX: 'auto'
+              }}
+            >
               <DataGrid
                 rows={filteredProjects}
                 columns={columns}
@@ -282,6 +288,7 @@ export const ProjectsPage = (): JSX.Element => {
                     })
                 }}
                 sx={{
+                  minWidth: isSmDown ? 560 : undefined,
                   '& .MuiDataGrid-row': {
                     maxHeight: 'none !important'
                   },
@@ -296,6 +303,11 @@ export const ProjectsPage = (): JSX.Element => {
                     whiteSpace: 'normal',
                     lineHeight: 1.2,
                     fontSize: { xs: '0.8rem', sm: '0.875rem' }
+                  },
+                  '& .MuiDataGrid-footerContainer': {
+                    flexWrap: 'wrap',
+                    gap: 1,
+                    justifyContent: { xs: 'center', sm: 'space-between' }
                   }
                 }}
                 density={isSmDown ? 'comfortable' : 'standard'}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -139,7 +139,13 @@ export const SettingsPage = (): JSX.Element => {
                 {addMutation.isPending ? t('common.savingWhitelist') : t('settings.add')}
               </Button>
             </Stack>
-            <Box sx={{ height: isSmDown ? 'auto' : 360, width: '100%' }}>
+            <Box
+              sx={{
+                width: '100%',
+                height: isSmDown ? 'auto' : 360,
+                overflowX: 'auto'
+              }}
+            >
               <DataGrid
                 rows={whitelistQuery.data ?? []}
                 columns={whitelistColumns}
@@ -151,6 +157,7 @@ export const SettingsPage = (): JSX.Element => {
                 disableRowSelectionOnClick
                 localeText={{ noRowsLabel: t('settings.whitelistEmpty') }}
                 sx={{
+                  minWidth: isSmDown ? 520 : undefined,
                   '& .MuiDataGrid-cell': {
                     alignItems: 'flex-start',
                     whiteSpace: 'normal',
@@ -161,6 +168,11 @@ export const SettingsPage = (): JSX.Element => {
                     whiteSpace: 'normal',
                     lineHeight: 1.2,
                     fontSize: { xs: '0.8rem', sm: '0.875rem' }
+                  },
+                  '& .MuiDataGrid-footerContainer': {
+                    flexWrap: 'wrap',
+                    gap: 1,
+                    justifyContent: { xs: 'center', sm: 'space-between' }
                   }
                 }}
                 density={isSmDown ? 'comfortable' : 'standard'}


### PR DESCRIPTION
## Summary
- add a swipeable mobile control panel with a dedicated toggle button
- extend navigation translations for the new control panel actions
- tighten responsive DataGrid layouts across logs, projects, ping services, and settings pages

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4460d8988832aa1f599213dcda524