### PR TITLE
Fix dashboard chart import for react-chartjs-2

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/material';
 import type { SxProps } from '@mui/material';
 import Grid from '@mui/material/Grid';
-import { Bar } from 'react-chartjs-2';
+import { Chart } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
   BarElement,
@@ -197,7 +197,8 @@ export const DashboardPage = (): JSX.Element => {
               <Typography variant="h6" gutterBottom sx={{ fontWeight: 600 }}>
                 {t('dashboard.logDistribution')}
               </Typography>
-              <Bar
+              <Chart
+                type="bar"
                 data={logLevelsDistribution}
                 options={{
                   responsive: true,


### PR DESCRIPTION
## Summary
- replace the Dashboard's usage of the `Bar` helper with the generic `Chart` component from react-chartjs-2
- render the bar visualization by setting `type="bar"` to avoid missing export errors during TypeScript builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d470bec184832ab16976fc75a9c3d1