### PR TITLE
Add Telegram bot status endpoint and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@
 - Белый список IP и rate limiting для защиты API.
 - Веб-клиент с тёмной/светлой темой, поиском и детальным просмотром событий.
 
+## Проверка статуса Telegram-бота
+
+Администраторы могут запросить `GET /api/settings/telegram-status`, чтобы мгновенно понять, настроен ли токен `BOT_API_KEY` и запущен ли бот в режиме polling. Метод доступен из `ApiClient` как `getTelegramStatus()`.
+
+- Подробности в API: [docs/ru/api.md](docs/ru/api.md#настройки-безопасности-settings) · [docs/en/api.md](docs/en/api.md#security-settings-settings)
+- Раздел в справочнике: [docs/ru/logger_api_reference.md](docs/ru/logger_api_reference.md#66-get-telegram-status) · [docs/en/logger_api_reference.md](docs/en/logger_api_reference.md#66-get-telegram-status)
+- Описание клиента: [docs/ts-library-doc/ApiClient-ru.md](docs/ts-library-doc/ApiClient-ru.md#настройки-api) · [docs/ts-library-doc/ApiClient-en.md](docs/ts-library-doc/ApiClient-en.md#api-settings)
+
 ## Компоненты проекта
 
 | Каталог | Описание |

--- a/README_EN.md
+++ b/README_EN.md
@@ -22,6 +22,14 @@ The platform ingests structured logs, tracks service uptime, and forwards alerts
 - IP whitelist and rate limiting to protect the API.
 - Web client with dark/light themes, search, and detailed log views.
 
+## Telegram bot status check
+
+Administrators can call `GET /api/settings/telegram-status` to instantly verify that the `BOT_API_KEY` token is configured and the bot is polling. The same functionality is exposed in `ApiClient` through `getTelegramStatus()`.
+
+- API overview: [docs/en/api.md](docs/en/api.md#security-settings-settings) · [docs/ru/api.md](docs/ru/api.md#настройки-безопасности-settings)
+- Reference guide: [docs/en/logger_api_reference.md](docs/en/logger_api_reference.md#66-get-telegram-status) · [docs/ru/logger_api_reference.md](docs/ru/logger_api_reference.md#66-get-telegram-status)
+- SDK docs: [docs/ts-library-doc/ApiClient-en.md](docs/ts-library-doc/ApiClient-en.md#api-settings) · [docs/ts-library-doc/ApiClient-ru.md](docs/ts-library-doc/ApiClient-ru.md#настройки-api)
+
 ## Project components
 
 | Path | Description |

--- a/api/src/api/controllers/settingsController.ts
+++ b/api/src/api/controllers/settingsController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 import { WhitelistModel } from '../models/Whitelist';
 import { getRateLimitValue, updateRateLimitValue } from '../services/systemSettings';
+import { defaultNotifier } from '../../telegram/notifier';
 
 const whitelistSchema = z.object({
   ip: z.string().min(3),
@@ -63,4 +64,12 @@ export async function updateRateLimit(req: Request, res: Response): Promise<Resp
 
   const updated = await updateRateLimitValue(parsed.data.rateLimitPerMinute);
   return res.json({ rateLimitPerMinute: updated.rateLimitPerMinute });
+}
+
+/**
+ * Возвращает статус Telegram-бота.
+ */
+export function getTelegramStatus(_req: Request, res: Response): Response {
+  const status = defaultNotifier.getStatus();
+  return res.json(status);
 }

--- a/api/src/api/routes/settingsRoutes.ts
+++ b/api/src/api/routes/settingsRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   addWhitelistIp,
+  getTelegramStatus,
   getRateLimit,
   listWhitelist,
   removeWhitelistIp,
@@ -15,5 +16,6 @@ router.post('/whitelist', authGuard, addWhitelistIp);
 router.delete('/whitelist/:ip', authGuard, removeWhitelistIp);
 router.get('/rate-limit', authGuard, getRateLimit);
 router.put('/rate-limit', authGuard, updateRateLimit);
+router.get('/telegram-status', authGuard, getTelegramStatus);
 
 export default router;

--- a/api/src/telegram/notifier.ts
+++ b/api/src/telegram/notifier.ts
@@ -81,6 +81,15 @@ export class TelegramNotifier {
   }
 
   /**
+   * Возвращает информацию о текущем состоянии Telegram-бота.
+   */
+  getStatus(): { tokenProvided: boolean; botStarted: boolean } {
+    const tokenProvided = Boolean(this.token);
+    const botStarted = Boolean(this.bot?.isPolling?.());
+    return { tokenProvided, botStarted };
+  }
+
+  /**
    * Отправляет уведомление для всех получателей проекта, учитывая анти-спам интервал.
    */
   async notify(project: ProjectDocument, message: string, tag: string): Promise<void> {

--- a/api/swaggerapi/openapi.yaml
+++ b/api/swaggerapi/openapi.yaml
@@ -610,6 +610,22 @@ paths:
           $ref: '#/components/responses/UnauthorizedResponse'
         '403':
           $ref: '#/components/responses/ForbiddenResponse'
+  /api/settings/telegram-status:
+    get:
+      tags: [Settings]
+      summary: Проверка статуса Telegram-бота
+      description: Возвращает информацию о том, передан ли ключ `BOT_API_KEY` и активен ли бот.
+      responses:
+        '200':
+          description: Текущее состояние интеграции с Telegram.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TelegramStatus'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
 components:
   securitySchemes:
     BearerAuth:
@@ -762,6 +778,18 @@ components:
           description: Интервал между уведомлениями в минутах.
           default: 15
           minimum: 1
+    TelegramStatus:
+      type: object
+      required: [tokenProvided, botStarted]
+      properties:
+        tokenProvided:
+          type: boolean
+          description: Установлена ли переменная окружения `BOT_API_KEY`.
+          example: true
+        botStarted:
+          type: boolean
+          description: Удалось ли запустить бота и начать polling.
+          example: true
     ProjectInput:
       type: object
       required:

--- a/api/swaggerapi/openapi_en.yaml
+++ b/api/swaggerapi/openapi_en.yaml
@@ -583,6 +583,22 @@ paths:
           $ref: '#/components/responses/UnauthorizedResponse'
         '403':
           $ref: '#/components/responses/ForbiddenResponse'
+  /api/settings/telegram-status:
+    get:
+      tags: [Settings]
+      summary: Check Telegram bot status
+      description: Returns whether the `BOT_API_KEY` is configured and if the bot is currently running.
+      responses:
+        '200':
+          description: Current Telegram integration status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TelegramStatus'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
     put:
       tags: [Settings]
       summary: Update rate limit value
@@ -762,6 +778,18 @@ components:
           description: Interval between notifications in minutes.
           default: 15
           minimum: 1
+    TelegramStatus:
+      type: object
+      required: [tokenProvided, botStarted]
+      properties:
+        tokenProvided:
+          type: boolean
+          description: Whether the `BOT_API_KEY` environment variable is set.
+          example: true
+        botStarted:
+          type: boolean
+          description: Indicates if the bot successfully started polling.
+          example: true
     ProjectInput:
       type: object
       required:

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -135,6 +135,7 @@ Authorization: Bearer <token>
 | `DELETE` | `/whitelist/:ip` | Remove an IP address. |
 | `GET` | `/rate-limit` | Inspect the current requests-per-minute cap. |
 | `PUT` | `/rate-limit` | Change the requests-per-minute cap. |
+| `GET` | `/telegram-status` | Verify that the Telegram bot is configured and polling. |
 
 Sample request:
 
@@ -150,6 +151,15 @@ Content-Type: application/json
 ```
 
 To tweak the rate limiter send `PUT /api/settings/rate-limit` with a JSON payload like `{ "rateLimitPerMinute": 200 }`.
+
+To confirm that the Telegram bot is online, call `GET /api/settings/telegram-status`. A `200 OK` response returns `tokenProvided` and `botStarted` flags that reflect the presence of `BOT_API_KEY` and the polling state:
+
+```json
+{
+  "tokenProvided": true,
+  "botStarted": true
+}
+```
 
 ## Swagger and OpenAPI
 

--- a/docs/en/logger_api_reference.md
+++ b/docs/en/logger_api_reference.md
@@ -227,6 +227,23 @@ Content-Type: application/json
 
 The response repeats the new limit value.
 
+### 6.6 GET `/telegram-status`
+Check whether the Telegram bot is configured and polling.
+
+```http
+GET /api/settings/telegram-status
+Authorization: Bearer <token>
+```
+
+**Response `200 OK`**
+
+```json
+{
+  "tokenProvided": true,
+  "botStarted": true
+}
+```
+
 ## 7. System endpoints
 
 - `GET /health` – service readiness probe (without the `/api` prefix).

--- a/docs/ru/api.md
+++ b/docs/ru/api.md
@@ -135,6 +135,7 @@ Authorization: Bearer <token>
 | `DELETE` | `/whitelist/:ip` | Удалить IP. |
 | `GET` | `/rate-limit` | Узнать текущее ограничение запросов в минуту. |
 | `PUT` | `/rate-limit` | Изменить значение ограничения запросов в минуту. |
+| `GET` | `/telegram-status` | Проверить, настроен ли Telegram-бот и запущен ли polling. |
 
 Запрос на добавление IP:
 
@@ -150,6 +151,15 @@ Content-Type: application/json
 ```
 
 Для изменения лимита скорости используйте запрос `PUT /api/settings/rate-limit` с телом вида `{ "rateLimitPerMinute": 200 }`.
+
+Чтобы убедиться, что Telegram-бот активен, выполните `GET /api/settings/telegram-status`. Ответ `200 OK` содержит поля `tokenProvided` и `botStarted`, которые показывают наличие ключа `BOT_API_KEY` и успешный запуск polling:
+
+```json
+{
+  "tokenProvided": true,
+  "botStarted": true
+}
+```
 
 ## Swagger и OpenAPI
 

--- a/docs/ru/logger_api_reference.md
+++ b/docs/ru/logger_api_reference.md
@@ -227,6 +227,23 @@ Content-Type: application/json
 
 Успешный ответ повторяет новое значение лимита.
 
+### 6.6 GET `/telegram-status`
+Проверяет, настроен ли Telegram-бот и запущен ли polling.
+
+```http
+GET /api/settings/telegram-status
+Authorization: Bearer <token>
+```
+
+**Ответ `200 OK`**
+
+```json
+{
+  "tokenProvided": true,
+  "botStarted": true
+}
+```
+
 ## 7. Системные эндпоинты
 
 - `GET /health` — проверка готовности сервиса (без префикса `/api`).

--- a/docs/ts-library-doc/ApiClient-en.md
+++ b/docs/ts-library-doc/ApiClient-en.md
@@ -73,6 +73,12 @@ all protected endpoints.
 - `upsertWhitelistEntry(payload)` — `POST /api/settings/whitelist`.
 - `deleteWhitelist(ip)` — `DELETE /api/settings/whitelist/{ip}`.
 
+### API settings
+
+- `getRateLimitSettings()` — `GET /api/settings/rate-limit`, returns `{ rateLimitPerMinute }`.
+- `updateRateLimitSettings(payload)` — `PUT /api/settings/rate-limit`.
+- `getTelegramStatus()` — `GET /api/settings/telegram-status`, returns `{ tokenProvided, botStarted }`.
+
 ## Error handling
 
 When the API responds with a non-success status, `ApiClient` throws an `ApiError` instance with

--- a/docs/ts-library-doc/ApiClient-ru.md
+++ b/docs/ts-library-doc/ApiClient-ru.md
@@ -77,6 +77,12 @@ await client.login({ username: 'admin', password: 'secret' });
 - `upsertWhitelistEntry(payload)` — `POST /api/settings/whitelist`.
 - `deleteWhitelist(ip)` — `DELETE /api/settings/whitelist/{ip}`.
 
+### Настройки API
+
+- `getRateLimitSettings()` — `GET /api/settings/rate-limit`, возвращает `{ rateLimitPerMinute }`.
+- `updateRateLimitSettings(payload)` — `PUT /api/settings/rate-limit`.
+- `getTelegramStatus()` — `GET /api/settings/telegram-status`, отвечает `{ tokenProvided, botStarted }`.
+
 ## Обработка ошибок
 
 Если API возвращает статус `>= 400`, клиент выбрасывает `ApiError` с полями:

--- a/ts-library/src/apiClient.ts
+++ b/ts-library/src/apiClient.ts
@@ -21,6 +21,7 @@ import type {
   ProjectLogEntry,
   ProjectLogResponse,
   RateLimitSettings,
+  TelegramStatus,
   WhitelistEntry,
   WhitelistPayload
 } from './types.js';
@@ -266,6 +267,13 @@ export class ApiClient {
       method: 'PUT',
       body: JSON.stringify(payload)
     });
+  }
+
+  /**
+   * Проверяет статус Telegram-бота.
+   */
+  async getTelegramStatus(): Promise<TelegramStatus> {
+    return this.request<TelegramStatus>('/api/settings/telegram-status');
   }
 
   /**

--- a/ts-library/src/types.ts
+++ b/ts-library/src/types.ts
@@ -347,6 +347,14 @@ export interface RateLimitSettings {
 }
 
 /**
+ * Статус Telegram-бота, возвращаемый API настроек.
+ */
+export interface TelegramStatus {
+  tokenProvided: boolean;
+  botStarted: boolean;
+}
+
+/**
  * Состояние здорового сервиса.
  */
 export interface HealthResponse {


### PR DESCRIPTION
## Summary
- add a secured `/api/settings/telegram-status` endpoint that reports Telegram bot availability
- expose the new status check through the TypeScript ApiClient and document the response in OpenAPI specs
- refresh Russian and English guides plus the READMEs with Telegram bot status instructions and links

## Testing
- npm test (api)
- npm test (ts-library)


------
https://chatgpt.com/codex/tasks/task_e_68d5aa8fea8c832aa97b5f11855dac4d