### PR TITLE
Fix ping table layout and show API base on dashboard

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -31,7 +31,7 @@ import { ErrorState } from '../components/common/ErrorState';
 import { formatDateTime, formatRelative } from '../utils/formatters';
 import { LogEntry, Project } from '../api/types';
 import { useTranslation } from '../hooks/useTranslation';
-import { API_URL } from '../config';
+import { getApiBaseUrl } from '../api/client';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -129,7 +129,7 @@ export const DashboardPage = (): JSX.Element => {
   const totalPingServices = pingQueries.reduce((acc, query) => acc + (query.data?.length ?? 0), 0);
   const projectsWithAlerts = projects?.filter((project) => project.telegramNotify.enabled).length ?? 0;
 
-  const apiBaseUrl = API_URL?.trim() ? API_URL : '';
+  const apiBaseUrl = getApiBaseUrl()?.trim() ?? '';
 
   const rateLimitPerMinute = rateLimitQuery.data?.rateLimitPerMinute;
 

--- a/client/src/pages/PingServicesPage.tsx
+++ b/client/src/pages/PingServicesPage.tsx
@@ -550,6 +550,7 @@ export const PingServicesPage = (): JSX.Element => {
                 getRowId={(row) => row._id}
                 columnVisibilityModel={columnVisibilityModel}
                 autoHeight={isSmDown}
+                rowHeight={isSmDown ? 96 : 76}
                 pageSizeOptions={[5, 10, 25]}
                 initialState={{ pagination: { paginationModel: { pageSize: 10, page: 0 } } }}
                 disableRowSelectionOnClick
@@ -557,8 +558,9 @@ export const PingServicesPage = (): JSX.Element => {
                 sx={{
                   minWidth: isSmDown ? 560 : undefined,
                   '& .MuiDataGrid-cell': {
-                    alignItems: 'center',
-                    py: 1.25,
+                    alignItems: 'flex-start',
+                    display: 'flex',
+                    py: 1.5,
                     fontSize: { xs: '0.875rem', sm: '0.95rem' }
                   },
                   '& .MuiDataGrid-cellContent': {


### PR DESCRIPTION
## Summary
- adjust the Ping Monitoring table row height and cell alignment so service data and actions stay visible
- show the currently configured API base URL on the dashboard by reading it from the client runtime settings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cb8d8cfc832a941a65fe520431c4